### PR TITLE
Reduce satellite point size in visualization

### DIFF
--- a/src/components/Monitor/utils/satelliteUtils.ts
+++ b/src/components/Monitor/utils/satelliteUtils.ts
@@ -117,7 +117,7 @@ export const createSatellitePoints = (scene: THREE.Scene, tleData: TLEData[]) =>
 
     const material = new THREE.PointsMaterial({
         color: 0x00ff00,
-        size: 0.03,
+        size: 0.005,
         map: createCircleTexture(),
         transparent: true,
         alphaTest: 0.5


### PR DESCRIPTION
Adjusted the THREE.PointsMaterial size from 0.03 to 0.005 in createSatellitePoints to make satellite points appear smaller in the scene for improved visual clarity.