### PR TITLE
Adjust camera position for tablet devices

### DIFF
--- a/src/components/Monitor/hooks/useThreeScene.ts
+++ b/src/components/Monitor/hooks/useThreeScene.ts
@@ -85,7 +85,7 @@ export const useThreeScene = (
                 controls.minDistance = 8;
             } else if (deviceType === 'tablet') {
                 scene.position.y = 0;
-                camera.position.z = 10;
+                camera.position.z = 14;
                 camera.position.y = 2;
                 controls.minDistance = 6;
             } else {


### PR DESCRIPTION
Increased the camera's z position from 10 to 14 for tablet devices to improve scene visibility and user experience.