### PR TITLE
Remove redundant camera y position for tablet and other devices

### DIFF
--- a/src/components/Monitor/hooks/useThreeScene.ts
+++ b/src/components/Monitor/hooks/useThreeScene.ts
@@ -86,12 +86,10 @@ export const useThreeScene = (
             } else if (deviceType === 'tablet') {
                 scene.position.y = 0;
                 camera.position.z = 12;
-                camera.position.y = 2;
                 controls.minDistance = 6;
             } else {
                 scene.position.y = 0;
                 camera.position.z = 10;
-                camera.position.y = 2;
                 controls.minDistance = 6;
             }
             controls.update();


### PR DESCRIPTION
Eliminated unnecessary assignments to camera.position.y for tablet and other device types in useThreeScene hook, as they were not needed for scene setup.