### PR TITLE
Automate Starlink availability sync (with attribution)

### DIFF
--- a/.github/workflows/sync-starlink-availability.yml
+++ b/.github/workflows/sync-starlink-availability.yml
@@ -1,0 +1,67 @@
+name: Sync Starlink availability
+
+# Weekly low-frequency mirror of Starlink’s public map availability JSON.
+# Opens a PR when the feed changes. Not an official Starlink API integration.
+on:
+  schedule:
+    # Mondays 06:00 UTC — availability changes infrequently.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-starlink-availability
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Sync availability feed
+        run: node scripts/sync-starlink-availability.mjs
+
+      - name: Create pull request when data changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            chore: sync Starlink availability map data
+
+            Update public/json/availability.json from Starlink’s public map
+            feed (api.starlink.com/public-files/availability.json).
+          branch: chore/sync-starlink-availability
+          delete-branch: true
+          title: Sync Starlink availability map data
+          body: |
+            ## Summary
+
+            Automated sync of `public/json/availability.json` from Starlink’s
+            public map feed:
+
+            - Source: https://api.starlink.com/public-files/availability.json
+            - Map: https://www.starlink.com/map
+
+            This workflow fetches the public JSON at most weekly, attributes
+            the source in `public/json/availability.meta.json`, and does not
+            hotlink the feed from browsers.
+
+            Starmonitor is not affiliated with SpaceX or Starlink. Availability
+            data remains their material; stop or disable this workflow if they
+            request it.
+
+            Triggered by: `${{ github.event_name }}`
+          add-paths: |
+            public/json/availability.json
+            public/json/availability.meta.json

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 - **Live Satellite Tracking**: Real-time position updates for all Starlink satellites
 - **Interactive 3D Earth**: Mouse-controlled globe with orbital visualization
-- **Service Availability Map**: Starlink service status by country (manually updated from static data)
+- **Service Availability Map**: Starlink service status by country (synced from Starlink’s public map feed)
 - **Dynamic Country Classification**:
   - **Available**: Countries with active Starlink service
   - **Coming Soon**: Countries with planned service rollout
@@ -22,7 +22,7 @@
 - **Orbital Calculations**: satellite.js library
 - **Data Sources**:
   - Satellite TLE data from CelesTrak API
-  - Service availability from Starlink availability data (static JSON)
+  - Service availability from Starlink’s public map feed (`availability.json`), mirrored locally
   - Country borders from GeoJSON data
 
 ## Quick Start
@@ -48,9 +48,27 @@ npm run start    # Start production server
 The application combines multiple data sources:
 
 1. **Satellite Positions**: Fetches Two-Line Element (TLE) data from CelesTrak and calculates precise orbital positions using satellite.js
-2. **Service Availability**: Loads static service availability data from local JSON (sourced from Starlink and updated manually)
+2. **Service Availability**: Loads locally mirrored Starlink map availability data (see below)
 3. **Geographic Visualization**: Renders country borders from GeoJSON data with dynamic color coding based on service availability
-4. **Real-time Updates**: Satellite positions update every second, service data is static and refreshed via manual updates
+4. **Real-time Updates**: Satellite positions update every second; availability data is refreshed by the weekly sync workflow
+
+## Availability data sync
+
+Country service status comes from Starlink’s public map feed
+(`https://api.starlink.com/public-files/availability.json`), the same JSON used
+by [starlink.com/map](https://www.starlink.com/map).
+
+This is **not** an official Starlink developer API and Starmonitor is **not
+affiliated with SpaceX/Starlink**. The feed is mirrored infrequently (weekly
+GitHub Action + manual runs), attributed in-repo, and served from
+`public/json/availability.json` so browsers never hotlink Starlink’s CDN.
+
+```bash
+npm run sync:availability
+```
+
+Details: `public/json/DATA_NOTICE.md`. Disable
+`.github/workflows/sync-starlink-availability.yml` if the provider objects.
 
 ## Browser Support
 
@@ -58,4 +76,5 @@ Modern browsers with WebGL support (Chrome, Firefox, Safari, Edge).
 
 ## License
 
-MIT License
+MIT License for Starmonitor code (`LICENSE.md`). Starlink availability data is
+third-party material; see `public/json/DATA_NOTICE.md`.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "sync:availability": "node scripts/sync-starlink-availability.mjs"
   },
   "dependencies": {
     "next": "^16.0.7",

--- a/public/json/DATA_NOTICE.md
+++ b/public/json/DATA_NOTICE.md
@@ -1,0 +1,27 @@
+# Third-party data notice
+
+## Starlink service availability (`public/json/availability.json`)
+
+This file is periodically mirrored from Starlink’s public map feed:
+
+- https://api.starlink.com/public-files/availability.json
+- Used by https://www.starlink.com/map
+
+SpaceX / Starlink retain rights in their materials. Starmonitor is **not
+affiliated with, endorsed by, or sponsored by** SpaceX or Starlink.
+
+There is no published open license granting third parties an API right to this
+feed. The local copy exists only so the globe visualization can show publicly
+posted service-availability facts without browser hotlinking and without
+hammering their CDN.
+
+Automation policy used by this repository:
+
+1. Fetch the public JSON only (no HTML scraping, no authenticated APIs).
+2. Identify requests with a clear project User-Agent.
+3. Fetch at low frequency (weekly GitHub Action, plus manual runs).
+4. Keep attribution / sync metadata in `public/json/availability.meta.json`.
+5. Disable the sync workflow if Starlink asks or the feed becomes restricted.
+
+The MIT License in `LICENSE.md` applies to Starmonitor’s own code, not to
+Starlink’s availability data.

--- a/public/json/availability.meta.json
+++ b/public/json/availability.meta.json
@@ -1,0 +1,12 @@
+{
+  "sourceUrl": "https://api.starlink.com/public-files/availability.json",
+  "mapUrl": "https://www.starlink.com/map",
+  "provider": "SpaceX / Starlink",
+  "attribution": "Service availability data is sourced from Starlink’s public map feed and remains their material. This project is not affiliated with SpaceX or Starlink.",
+  "syncedAt": "2026-07-30T14:27:45.644Z",
+  "etag": "\"7c8110c7648de45846e78e9f1a203272\"",
+  "lastModified": "Tue, 28 Jul 2026 21:59:27 GMT",
+  "contentSha256": "c646296e5ac9fc9fdd9071272b88d63c41cfcc713e8c64a982d5db6c20922faf",
+  "admin0Count": 255,
+  "admin1Count": 46
+}

--- a/scripts/sync-starlink-availability.mjs
+++ b/scripts/sync-starlink-availability.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * Sync Starlink service-availability map data from the public map feed.
+ *
+ * Source: https://api.starlink.com/public-files/availability.json
+ * (same JSON used by https://www.starlink.com/map)
+ *
+ * This is NOT an officially licensed Starlink developer API. The file is a
+ * public map asset. We fetch it infrequently, attribute the source, keep a
+ * local copy for the visualization, and do not hotlink it from browsers.
+ * SpaceX/Starlink retain rights in their materials. Stop syncing if asked.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SOURCE_URL = 'https://api.starlink.com/public-files/availability.json';
+const MAP_URL = 'https://www.starlink.com/map';
+const USER_AGENT =
+  'starmonitor-availability-sync/1.0 (+https://github.com/asyntes/starmonitor; weekly public map feed mirror)';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const OUTPUT_PATH = path.join(ROOT, 'public/json/availability.json');
+const META_PATH = path.join(ROOT, 'public/json/availability.meta.json');
+
+const KNOWN_STATUSES = new Set([
+  'available',
+  'launched',
+  'coming_soon',
+  'pending_regulatory',
+  'unknown',
+  'blacklisted',
+  'exclude',
+  'faq',
+]);
+
+function fail(message) {
+  console.error(`sync-starlink-availability: ${message}`);
+  process.exit(1);
+}
+
+function isStatusEntry(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof value.status === 'string' &&
+    value.status.length > 0 &&
+    (value.expected === undefined || typeof value.expected === 'string')
+  );
+}
+
+function validateAvailability(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    fail('payload is not a JSON object');
+  }
+  if (!data.admin0 || typeof data.admin0 !== 'object' || Array.isArray(data.admin0)) {
+    fail('missing admin0 object');
+  }
+
+  const admin0Keys = Object.keys(data.admin0);
+  if (admin0Keys.length < 100) {
+    fail(`admin0 looks too small (${admin0Keys.length} keys)`);
+  }
+
+  const seenStatuses = new Set();
+  for (const [code, entry] of Object.entries(data.admin0)) {
+    if (!/^[A-Z]{2}$/.test(code)) {
+      fail(`invalid admin0 country code: ${code}`);
+    }
+    if (!isStatusEntry(entry)) {
+      fail(`invalid admin0 entry for ${code}`);
+    }
+    seenStatuses.add(entry.status);
+  }
+
+  if (data.admin1 !== undefined) {
+    if (typeof data.admin1 !== 'object' || Array.isArray(data.admin1)) {
+      fail('admin1 must be an object when present');
+    }
+    for (const [key, entry] of Object.entries(data.admin1)) {
+      if (typeof key !== 'string' || key.length === 0) {
+        fail('invalid admin1 key');
+      }
+      if (!isStatusEntry(entry)) {
+        fail(`invalid admin1 entry for ${key}`);
+      }
+      seenStatuses.add(entry.status);
+    }
+  }
+
+  const unknown = [...seenStatuses].filter((status) => !KNOWN_STATUSES.has(status));
+  if (unknown.length > 0) {
+    console.warn(
+      `sync-starlink-availability: new status values from feed: ${unknown.join(', ')}`,
+    );
+  }
+}
+
+function serialize(data) {
+  // Match the official feed formatting (4-space indent, no trailing newline).
+  return `${JSON.stringify(data, null, 4)}`;
+}
+
+async function readExisting(filePath) {
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function main() {
+  const response = await fetch(SOURCE_URL, {
+    headers: {
+      Accept: 'application/json',
+      'User-Agent': USER_AGENT,
+    },
+    redirect: 'follow',
+  });
+
+  if (!response.ok) {
+    fail(`HTTP ${response.status} fetching ${SOURCE_URL}`);
+  }
+
+  const rawText = await response.text();
+  let data;
+  try {
+    data = JSON.parse(rawText);
+  } catch {
+    fail('response is not valid JSON');
+  }
+
+  validateAvailability(data);
+
+  const nextContent = serialize(data);
+  const previousContent = await readExisting(OUTPUT_PATH);
+  const previousMeta = await readExisting(META_PATH);
+  const changed = previousContent !== nextContent;
+
+  await mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
+
+  const meta = {
+    sourceUrl: SOURCE_URL,
+    mapUrl: MAP_URL,
+    provider: 'SpaceX / Starlink',
+    attribution:
+      'Service availability data is sourced from Starlink’s public map feed and remains their material. This project is not affiliated with SpaceX or Starlink.',
+    syncedAt: new Date().toISOString(),
+    etag: response.headers.get('etag'),
+    lastModified: response.headers.get('last-modified'),
+    contentSha256: createHash('sha256').update(nextContent).digest('hex'),
+    admin0Count: Object.keys(data.admin0).length,
+    admin1Count: data.admin1 ? Object.keys(data.admin1).length : 0,
+  };
+
+  // Avoid weekly no-op PRs: only touch the repo when the feed (or missing meta) changes.
+  if (changed) {
+    await writeFile(OUTPUT_PATH, nextContent, 'utf8');
+    await writeFile(META_PATH, `${JSON.stringify(meta, null, 2)}\n`, 'utf8');
+  } else if (previousMeta === null) {
+    await writeFile(META_PATH, `${JSON.stringify(meta, null, 2)}\n`, 'utf8');
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        changed,
+        wroteMeta: changed || previousMeta === null,
+        output: path.relative(ROOT, OUTPUT_PATH),
+        meta: path.relative(ROOT, META_PATH),
+        admin0Count: meta.admin0Count,
+        admin1Count: meta.admin1Count,
+        lastModified: meta.lastModified,
+      },
+      null,
+      2,
+    ),
+  );
+
+  process.exit(0);
+}
+
+main().catch((error) => {
+  fail(error instanceof Error ? error.message : String(error));
+});

--- a/src/components/Monitor/services/starlinkAvailability.ts
+++ b/src/components/Monitor/services/starlinkAvailability.ts
@@ -158,7 +158,9 @@ const COUNTRY_NAME_TO_CODE_MAP: Record<string, string> = {
 };
 
 export const fetchStarlinkAvailability = async (): Promise<void> => {
-    const localUrl = '/json/availability.json';  // Percorso relativo alla root public
+    // Local mirror of Starlink's public map feed. See public/json/DATA_NOTICE.md
+    // and `npm run sync:availability` / .github/workflows/sync-starlink-availability.yml
+    const localUrl = '/json/availability.json';
 
     try {
         const response = await fetch(localUrl);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rende automatico l’aggiornamento di `public/json/availability.json` nel modo più prudente possibile, senza una licenza ufficiale Starlink.

## Contesto legale (importante)

Starlink **non pubblica una licenza open** per il feed della mappa. Non esiste quindi un’automazione “ufficialmente autorizzata”. L’approccio qui è il più compliant in pratica:

- si usa solo il JSON pubblico della mappa (`api.starlink.com/public-files/availability.json`), non scraping HTML né API autenticate
- fetch **infrequente** (settimanale) con User-Agent identificabile
- **nessun hotlink** dal browser: i client continuano a leggere la copia locale
- attribution + disclaimer in `public/json/DATA_NOTICE.md` e `availability.meta.json`
- MIT del repo **non** si applica ai dati Starlink
- il workflow si può disabilitare subito se SpaceX/Starlink lo richiedono

Questo **non è consulenza legale**. L’unica certezza assoluta resta un permesso scritto da SpaceX/Starlink.

## Cosa aggiunge

- `scripts/sync-starlink-availability.mjs` + `npm run sync:availability`
- `.github/workflows/sync-starlink-availability.yml` (cron settimanale + `workflow_dispatch`) che apre una PR solo se il feed cambia
- notice/attribution e aggiornamento README

## Verifica

- Sync eseguito con successo contro il feed ufficiale
- Idempotente: seconda esecuzione non riscrive i file se i dati sono invariati
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb365-1da2-77a3-a62e-9ad794850c45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb365-1da2-77a3-a62e-9ad794850c45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

